### PR TITLE
move everything into a class to reduce duplication

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,11 @@ The current configurable values are:
   - defaults to: `[]`
   - use `.gitignore` syntax, and make sure to use the directory wildcard as needed
 
+#### `user_id`
+  - defaults to `None`
+  - Used to uniquely identify the instance, this is useful if multiple remote-docker agents
+  will be created in the same AWS account
+
 #### `watched_directories`
  - defaults to: `[]`
  - list of paths to watch by `rd sync`

--- a/src/remote_docker_aws/cli_commands.py
+++ b/src/remote_docker_aws/cli_commands.py
@@ -1,7 +1,7 @@
 import click
 import os
 import sys
-from typing import List, Tuple
+from typing import Tuple
 
 from .core import (
     create_remote_docker_client,
@@ -152,5 +152,5 @@ def cmd_tunnel(client: RemoteDockerClient, local, remote):
 @cli.command(name="sync", help="Sync the given directories with the remote instance")
 @click.argument("directory", nargs=-1)
 @pass_config
-def cmd_sync(client: RemoteDockerClient, directory: List[str]):
-    client.sync(extra_sync_dirs=directory)
+def cmd_sync(client: RemoteDockerClient, directory: Tuple[str]):
+    client.sync(extra_sync_dirs=list(directory))

--- a/src/remote_docker_aws/config.py
+++ b/src/remote_docker_aws/config.py
@@ -2,7 +2,13 @@ import json
 import os
 from typing import Dict, List
 
-from .constants import INSTANCE_TYPE_DEFAULT, PORT_MAP_TYPE
+from .constants import (
+    KEY_PAIR_NAME,
+    INSTANCE_SERVICE_NAME,
+    INSTANCE_TYPE_DEFAULT,
+    PORT_MAP_TYPE,
+    SCEPTRE_PROJECT_CODE,
+)
 
 
 _UNSET = object()
@@ -126,21 +132,31 @@ class RemoteDockerConfigProfile(JSONConfigWithProfile):
     def watched_directories(self) -> List[str]:
         return [
             os.path.expanduser(watched_dir)
-            for watched_dir in self.get_attribute("watched_directories")
+            for watched_dir in self.get_attribute("watched_directories", [])
         ]
 
     @property
     def instance_type(self) -> str:
         return self.get_attribute("instance_type", INSTANCE_TYPE_DEFAULT)
 
-    def add_watched_directories(self, dirs: List[str]):
-        self.config_dict.setdefault("watched_directories", [])
-        self.config_dict["watched_directories"].extend(dirs)
+    @property
+    def key_pair_name(self) -> str:
+        if not self.user_id:
+            return KEY_PAIR_NAME
+        return f"{KEY_PAIR_NAME}-{self.user_id}"
 
-    def add_local_port_forwards(self, key: str, local_port_forwards: Dict):
-        self.config_dict.setdefault("local_port_forwards", {})
-        self.config_dict["local_port_forwards"][key] = local_port_forwards
+    @property
+    def instance_service_name(self) -> str:
+        if not self.user_id:
+            return INSTANCE_SERVICE_NAME
+        return f"{INSTANCE_SERVICE_NAME}-{self.user_id}"
 
-    def add_remote_port_forwards(self, key: str, remote_port_forwards: Dict):
-        self.config_dict.setdefault("remote_port_forwards", {})
-        self.config_dict["remote_port_forwards"][key] = remote_port_forwards
+    @property
+    def project_code(self) -> str:
+        if not self.user_id:
+            return SCEPTRE_PROJECT_CODE
+        return f"{SCEPTRE_PROJECT_CODE}-{self.user_id}"
+
+    @property
+    def user_id(self) -> str:
+        return self.get_attribute("user_id", None)

--- a/src/remote_docker_aws/config.py
+++ b/src/remote_docker_aws/config.py
@@ -1,6 +1,6 @@
 import json
 import os
-from typing import Dict, List
+from typing import List
 
 from .constants import (
     KEY_PAIR_NAME,

--- a/src/remote_docker_aws/constants.py
+++ b/src/remote_docker_aws/constants.py
@@ -1,3 +1,5 @@
+import os
+import pathlib
 from typing import Dict
 
 
@@ -8,6 +10,8 @@ INSTANCE_USERNAME = "ubuntu"
 # Used to identify the ec2 instance
 INSTANCE_SERVICE_NAME = "remote-docker-ec2-agent"
 INSTANCE_TYPE_DEFAULT = "t2.medium"
+SCEPTRE_PATH = os.path.join(pathlib.Path(__file__).parent.absolute(), "sceptre")
+SCEPTRE_PROJECT_CODE = "remote-docker"
 
 
 # Looked up via https://cloud-images.ubuntu.com/locator/ec2/

--- a/src/remote_docker_aws/core.py
+++ b/src/remote_docker_aws/core.py
@@ -265,17 +265,16 @@ class RemoteDockerClient:
 
     def create_keypair(self) -> Dict:
         path = self.ssh_key_path
+        # shell=True with `ssh-keygen` doesn't seem to be passing path correctly
         subprocess.run(
             shlex.split(f"ssh-keygen -t rsa -b 4096 -f {path}"),
             check=True,
-            shell=True,
             stdout=sys.stdout,
             stderr=sys.stderr,
         )
         subprocess.run(
             shlex.split(f"ssh-add -K {path}"),
             check=True,
-            shell=True,
             stdout=sys.stdout,
             stderr=sys.stderr,
         )

--- a/src/remote_docker_aws/core.py
+++ b/src/remote_docker_aws/core.py
@@ -40,7 +40,6 @@ class RemoteDockerClient:
         ssh_key_pair_name: str,
         sync_dirs: List[str],
         sync_ignore_patterns: List[str],
-        sceptre_path: str,
     ):
         self.project_code = project_code
         self.aws_region = aws_region
@@ -52,10 +51,9 @@ class RemoteDockerClient:
         self.ssh_key_pair_name = ssh_key_pair_name
         self.sync_dirs = sync_dirs
         self.sync_ignore_patterns = sync_ignore_patterns
-        self.sceptre_path = sceptre_path
 
     @classmethod
-    def from_config(cls, config: RemoteDockerConfigProfile, sceptre_path: str):
+    def from_config(cls, config: RemoteDockerConfigProfile):
         return cls(
             project_code=config.project_code,
             aws_region=config.aws_region,
@@ -67,7 +65,6 @@ class RemoteDockerClient:
             ssh_key_pair_name=config.key_pair_name,
             sync_dirs=config.watched_directories,
             sync_ignore_patterns=config.sync_ignore_patterns_git,
-            sceptre_path=sceptre_path,
         )
 
     @property
@@ -170,7 +167,7 @@ class RemoteDockerClient:
 
     def _get_sceptre_plan(self) -> SceptrePlan:
         context = SceptreContext(
-            self.sceptre_path,
+            SCEPTRE_PATH,
             "dev/application.yaml",
             user_variables=dict(
                 key_pair_name=self.ssh_key_pair_name,
@@ -356,4 +353,4 @@ class RemoteDockerClient:
 def create_remote_docker_client(
     config: RemoteDockerConfigProfile,
 ) -> RemoteDockerClient:
-    return RemoteDockerClient.from_config(config, SCEPTRE_PATH)
+    return RemoteDockerClient.from_config(config)

--- a/src/remote_docker_aws/core.py
+++ b/src/remote_docker_aws/core.py
@@ -1,5 +1,4 @@
 import os
-import pathlib
 import shlex
 import subprocess
 import sys
@@ -12,13 +11,13 @@ from sceptre.context import SceptreContext
 from sceptre.plan.plan import SceptrePlan
 from unison_gitignore.parser import GitIgnoreToUnisonIgnore
 
+from .config import RemoteDockerConfigProfile
 from .constants import (
     AWS_REGION_TO_UBUNTU_AMI_MAPPING,
     DOCKER_PORT_FORWARD,
-    KEY_PAIR_NAME,
-    INSTANCE_SERVICE_NAME,
     INSTANCE_USERNAME,
     PORT_MAP_TYPE,
+    SCEPTRE_PATH,
 )
 from .util import get_replica_and_sync_paths_for_unison, logger, wait_until_port_is_open
 
@@ -28,316 +27,333 @@ def get_ec2_client(region_name):
     return boto3.client("ec2", region_name=region_name)
 
 
-def search_for_instances(aws_region) -> Dict:
-    return get_ec2_client(aws_region).describe_instances(
-        Filters=[dict(Name="tag:service", Values=[INSTANCE_SERVICE_NAME])]
-    )
+class RemoteDockerClient:
+    def __init__(
+        self,
+        project_code: str,
+        aws_region: str,
+        instance_service_name: str,
+        instance_type: str,
+        local_forwards: PORT_MAP_TYPE,
+        remote_forwards: PORT_MAP_TYPE,
+        ssh_key_path: str,
+        ssh_key_pair_name: str,
+        sync_dirs: List[str],
+        sync_ignore_patterns: List[str],
+        sceptre_path: str,
+    ):
+        self.project_code = project_code
+        self.aws_region = aws_region
+        self.instance_service_name = instance_service_name
+        self.instance_type = instance_type
+        self.local_forwards = local_forwards
+        self.remote_forwards = remote_forwards
+        self.ssh_key_path = ssh_key_path
+        self.ssh_key_pair_name = ssh_key_pair_name
+        self.sync_dirs = sync_dirs
+        self.sync_ignore_patterns = sync_ignore_patterns
+        self.sceptre_path = sceptre_path
 
-
-def get_instance(aws_region) -> Dict:
-    reservations = search_for_instances(aws_region)["Reservations"]
-    valid_reservations = [
-        reservation
-        for reservation in reservations
-        if len(reservation["Instances"]) == 1
-        and reservation["Instances"][0]["State"]["Name"] != "terminated"
-    ]
-
-    if len(valid_reservations) == 0:
-        raise RuntimeError(
-            "There are no valid reservations, did you create the instance?"
+    @classmethod
+    def from_config(cls, config: RemoteDockerConfigProfile, sceptre_path: str):
+        return cls(
+            project_code=config.project_code,
+            aws_region=config.aws_region,
+            instance_service_name=config.instance_service_name,
+            instance_type=config.instance_type,
+            local_forwards=config.local_port_forwards,
+            remote_forwards=config.remote_port_forwards,
+            ssh_key_path=config.key_path,
+            ssh_key_pair_name=config.key_pair_name,
+            sync_dirs=config.watched_directories,
+            sync_ignore_patterns=config.sync_ignore_patterns_git,
+            sceptre_path=sceptre_path,
         )
-    if len(valid_reservations) > 1:
-        raise RuntimeError(
-            "There is more than one reservation found that matched, not sure what to do"
+
+    @property
+    def ec2_client(self):
+        return get_ec2_client(region_name=self.aws_region)
+
+    def search_for_instances(self) -> Dict:
+        return self.ec2_client.describe_instances(
+            Filters=[dict(Name="tag:service", Values=[self.instance_service_name])]
         )
 
-    instances = valid_reservations[0]["Instances"]
-    assert len(instances) == 1, f"{len(instances)} != 1"
-    return instances[0]
+    def get_instance(self) -> Dict:
+        reservations = self.search_for_instances()["Reservations"]
+        valid_reservations = [
+            reservation
+            for reservation in reservations
+            if len(reservation["Instances"]) == 1
+            and reservation["Instances"][0]["State"]["Name"] != "terminated"
+        ]
 
+        if len(valid_reservations) == 0:
+            raise RuntimeError(
+                "There are no valid reservations, did you create the instance?"
+            )
+        if len(valid_reservations) > 1:
+            raise RuntimeError(
+                "There is more than one reservation found that matched, not sure what to do"
+            )
 
-def get_ip(aws_region) -> str:
-    logger.info("Retrieving IP address of instance")
-    return get_instance(aws_region)["PublicIpAddress"]
+        instances = valid_reservations[0]["Instances"]
+        assert len(instances) == 1, f"{len(instances)} != 1"
+        return instances[0]
 
+    def get_ip(self) -> str:
+        logger.info("Retrieving IP address of instance")
+        return self.get_instance()["PublicIpAddress"]
 
-def get_instance_id(aws_region) -> str:
-    return get_instance(aws_region)["InstanceId"]
+    def get_instance_id(self) -> str:
+        return self.get_instance()["InstanceId"]
 
+    def get_instance_state(self) -> str:
+        return self.get_instance()["State"]["Name"]
 
-def get_instance_state(aws_region) -> str:
-    return get_instance(aws_region)["State"]["Name"]
+    def start_instance(self):
+        logger.warning("Starting instance")
+        return self.ec2_client.start_instances(InstanceIds=[self.get_instance_id()])
 
+    def stop_instance(self):
+        logger.warning("Stopping instance")
+        return self.ec2_client.stop_instances(InstanceIds=[self.get_instance_id()])
 
-def start_instance(aws_region):
-    logger.warning("Starting instance")
-    return get_ec2_client(aws_region).start_instances(
-        InstanceIds=[get_instance_id(aws_region)]
-    )
+    def start_tunnel(
+        self, *, extra_local_forwards=None, extra_remote_forwards=None,
+    ):
+        if extra_local_forwards is None:
+            extra_local_forwards = {}
+        if extra_remote_forwards is None:
+            extra_remote_forwards = {}
+        local_forwards = dict(self.local_forwards, **extra_local_forwards)
+        remote_forwards = dict(self.remote_forwards, **extra_remote_forwards)
 
+        ip = self.get_ip()
+        cmd_s = f"""
+        sudo ssh -v -o StrictHostKeyChecking=no -o "ServerAliveInterval=60" -N -T
+         -i {self.ssh_key_path} {INSTANCE_USERNAME}@{ip}
+        """
 
-def stop_instance(aws_region):
-    logger.warning("Stopping instance")
-    return get_ec2_client(aws_region).stop_instances(
-        InstanceIds=[get_instance_id(aws_region)]
-    )
-
-
-def start_tunnel(
-    *,
-    ssh_key_path: str,
-    local_forwards: PORT_MAP_TYPE,
-    remote_forwards: PORT_MAP_TYPE,
-    aws_region: str,
-):
-    ip = get_ip(aws_region)
-    cmd_s = f"""
-    sudo ssh -v -o StrictHostKeyChecking=no -o "ServerAliveInterval=60" -N -T
-     -i {ssh_key_path} {INSTANCE_USERNAME}@{ip}
-    """
-
-    for port_from, port_to in DOCKER_PORT_FORWARD.items():
-        cmd_s += f" -L localhost:{port_from}:localhost:{port_to}"
-
-    for _name, port_mappings in local_forwards.items():
-        for port_from, port_to in port_mappings.items():
+        for port_from, port_to in DOCKER_PORT_FORWARD.items():
             cmd_s += f" -L localhost:{port_from}:localhost:{port_to}"
 
-    for _name, port_mappings in remote_forwards.items():
-        for port_from, port_to in port_mappings.items():
-            cmd_s += f" -R 0.0.0.0:{port_from}:localhost:{port_to}"
+        for _name, port_mappings in local_forwards.items():
+            for port_from, port_to in port_mappings.items():
+                cmd_s += f" -L localhost:{port_from}:localhost:{port_to}"
 
-    logger.warning("Starting tunnel")
-    cmd = shlex.split(cmd_s)
-    logger.debug("Running cmd: %s", cmd)
+        for _name, port_mappings in remote_forwards.items():
+            for port_from, port_to in port_mappings.items():
+                cmd_s += f" -R 0.0.0.0:{port_from}:localhost:{port_to}"
 
-    logger.warning("")
-    logger.warning("Forwarding: ")
-    logger.warning("Local: %s", local_forwards)
-    logger.warning("Remote: %s", remote_forwards)
-    # Use `subprocess.run` instead of `os.execvp` because the latter
-    # prints a strange error: `sudo: setrlimit(RLIMIT_STACK): Invalid argument`
-    subprocess.run(cmd, check=True)
+        logger.warning("Starting tunnel")
+        cmd = shlex.split(cmd_s)
+        logger.debug("Running cmd: %s", cmd)
+
+        logger.warning("")
+        logger.warning("Forwarding: ")
+        logger.warning("Local: %s", self.local_forwards)
+        logger.warning("Remote: %s", self.remote_forwards)
+        # Use `subprocess.run` instead of `os.execvp` because the latter
+        # prints a strange error: `sudo: setrlimit(RLIMIT_STACK): Invalid argument`
+        subprocess.run(cmd, check=True)
+
+    def import_key(self, file_location) -> Dict:
+        with open(file_location, "r") as fh:
+            file_bytes = fh.read().strip().encode("utf-8")
+
+        return self.ec2_client.import_key_pair(
+            KeyName=self.ssh_key_pair_name,
+            # Documentation is lying, shouldn't be b64 encoded...
+            PublicKeyMaterial=file_bytes,
+        )
+
+    def _get_sceptre_plan(self) -> SceptrePlan:
+        context = SceptreContext(
+            self.sceptre_path,
+            "dev/application.yaml",
+            user_variables=dict(
+                key_pair_name=self.ssh_key_pair_name,
+                image_id=AWS_REGION_TO_UBUNTU_AMI_MAPPING[self.aws_region],
+                instance_type=self.instance_type,
+                project_code=self.project_code,
+                region=self.aws_region,
+                service_name=self.instance_service_name,
+            ),
+        )
+        return SceptrePlan(context)
+
+    def create_instance(self):
+        logger.warning("Creating instance")
+        result = self._get_sceptre_plan().create()
+
+        logger.debug("Got sceptre result: %s", result)
+        if "complete" not in result.values():
+            raise Exception(f"sceptre command failed: {list(result.values())}")
+        logger.warning("Stack created")
+
+        while self.get_instance_state() != "running":
+            logger.warning("Waiting to bootstrap: instance not yet running")
+            time.sleep(5)
+
+        logger.warning("Waiting until SSH access is available")
+        ip = self.get_ip()
+
+        wait_until_port_is_open(ip, 22, sleep_time=3, max_attempts=10)
+        # Give it some extra time, AWS can throw fopen errors on apt-get update
+        # if this is too rushed
+        time.sleep(15)
+        logger.warning("Starting bootstrap")
+        self.bootstrap_instance()
+
+    def update_instance(self) -> Dict:
+        logger.warning("Updating instance")
+        result = self._get_sceptre_plan().update()
+
+        logger.debug("Got sceptre result: %s", result)
+        if "complete" not in result.values():
+            raise Exception(f"sceptre command failed: {list(result.values())}")
+        return result
+
+    def delete_instance(self) -> Dict:
+        logger.warning("Deleting instance")
+        result = self._get_sceptre_plan().delete()
+
+        logger.debug("Got sceptre result: %s", result)
+        if "complete" not in result.values():
+            raise Exception(f"sceptre command failed: {list(result.values())}")
+        return result
+
+    def _build_ssh_cmd(self, ssh_cmd=None, options=None):
+        ssh_cmd = ssh_cmd if ssh_cmd else ""
+        options = options if options else ""
+
+        cmd_s = f"""
+        ssh -o StrictHostKeyChecking=no -i {self.ssh_key_path}
+        {options} {INSTANCE_USERNAME}@{self.get_ip()} {ssh_cmd}
+        """
+
+        return shlex.split(cmd_s)
+
+    def ssh_connect(self, *, ssh_cmd: str = None, options: str = None):
+        cmd = self._build_ssh_cmd(ssh_cmd, options)
+
+        os.execvp(cmd[0], cmd)
+
+    def ssh_run(self, *, ssh_cmd: str):
+        cmd = self._build_ssh_cmd(ssh_cmd)
+        return subprocess.run(cmd, check=True)
+
+    # flake8: noqa: E501
+    def bootstrap_instance(self):
+        logger.warning("Bootstrapping instance, will take a few minutes")
+        configure_instance_cmd_s = """
+        set -x
+        && sudo apt-get -y update
+        && sudo apt-get -y install build-essential curl file git docker.io
+        && "sudo sed -i -e '/ExecStart=/ s/fd:\/\//127\.0\.0\.1:2375/' '/lib/systemd/system/docker.service'"
+        && sudo systemctl daemon-reload
+        && sudo systemctl restart docker.service
+        && sudo systemctl enable docker.service
+        && "sudo sed -i -e '/GatewayPorts/ s/^.*$/GatewayPorts yes/' '/etc/ssh/sshd_config'"
+        && sudo service sshd restart
+        && /bin/bash -c '"$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"'
+        && eval $(/home/linuxbrew/.linuxbrew/bin/brew shellenv)
+        && echo 'eval $(/home/linuxbrew/.linuxbrew/bin/brew shellenv)' >> /home/ubuntu/.profile
+        && brew install unison eugenmayer/dockersync/unox
+        && sudo cp "$(which unison)" /usr/local/bin/
+        && sudo cp "$(which unison-fsmonitor)" /usr/local/bin/
+        """
+        self.ssh_connect(ssh_cmd=configure_instance_cmd_s)
+
+    def create_keypair(self) -> Dict:
+        path = self.ssh_key_path
+        subprocess.run(
+            shlex.split(f"ssh-keygen -t rsa -b 4096 -f {path}"),
+            check=True,
+            shell=True,
+            stdout=sys.stdout,
+            stderr=sys.stderr,
+        )
+        subprocess.run(
+            shlex.split(f"ssh-add -K {path}"),
+            check=True,
+            shell=True,
+            stdout=sys.stdout,
+            stderr=sys.stderr,
+        )
+        return self.import_key(file_location=f"{path}.pub",)
+
+    def _get_unison_cmd(
+        self,
+        *,
+        ip: str,
+        replica_path: str,
+        sync_paths: List[str],
+        force: bool = False,
+        repeat_watch: bool = False,
+    ) -> List[str]:
+        cmd_s = f"""
+        unison-gitignore {replica_path} 'ssh://{INSTANCE_USERNAME}@{ip}/{replica_path}'
+        -prefer {replica_path} -batch -sshargs '-i {self.ssh_key_path}'
+        """
+
+        parser = GitIgnoreToUnisonIgnore("/")
+        unison_patterns = parser.parse_gitignore(self.sync_ignore_patterns)
+        for unison_pattern in unison_patterns:
+            cmd_s += f' "{unison_pattern}"'
+
+        for sync_path in sync_paths:
+            cmd_s += f" -path {sync_path}"
+
+        if force:
+            cmd_s += f" -force {replica_path}"
+        if repeat_watch:
+            cmd_s += " -repeat watch"
+
+        return shlex.split(cmd_s.replace("\n", ""))
+
+    def sync(
+        self, *, extra_sync_dirs: List[str] = None,
+    ):
+        if extra_sync_dirs is None:
+            extra_sync_dirs = []
+        sync_dirs = [
+            os.path.expanduser(sync_dir)
+            for sync_dir in self.sync_dirs + extra_sync_dirs
+        ]
+
+        replica_path, sync_paths = get_replica_and_sync_paths_for_unison(sync_dirs)
+        ip = self.get_ip()
+
+        logger.warning("Ensuring remote directories exist")
+        ssh_cmd_s = f"sudo install -d -o {INSTANCE_USERNAME} -g {INSTANCE_USERNAME}"
+        for _dir in sync_dirs:
+            ssh_cmd_s += f" -p {_dir}"
+        self.ssh_run(ssh_cmd=ssh_cmd_s)
+
+        # First push the local replica's contents to remote
+        logger.info("Pushing local files to remote server")
+        subprocess.run(
+            self._get_unison_cmd(
+                ip=ip, replica_path=replica_path, sync_paths=sync_paths, force=True,
+            ),
+            check=True,
+        )
+
+        # Then watch for update
+        logger.info("Watching local and remote filesystems for changes")
+        watch_cmd = self._get_unison_cmd(
+            ip=ip, replica_path=replica_path, sync_paths=sync_paths, repeat_watch=True,
+        )
+
+        logger.warning("")
+        logger.warning("Watching: %s", sync_dirs)
+        logger.debug("Running command :%s", watch_cmd)
+        os.execvp(watch_cmd[0], watch_cmd)
 
 
-def import_key(name, file_location, aws_region) -> Dict:
-    with open(file_location, "r") as fh:
-        file_bytes = fh.read().strip().encode("utf-8")
-
-    return get_ec2_client(aws_region).import_key_pair(
-        KeyName=name,
-        # Documentation is lying, shouldn't be b64 encoded...
-        PublicKeyMaterial=file_bytes,
-    )
-
-
-def _get_sceptre_plan(region: str, instance_type: str = None) -> SceptrePlan:
-    sceptre_path = os.path.join(pathlib.Path(__file__).parent.absolute(), "sceptre")
-    context = SceptreContext(
-        sceptre_path,
-        "dev/application.yaml",
-        user_variables=dict(
-            key_pair_name=KEY_PAIR_NAME,
-            image_id=AWS_REGION_TO_UBUNTU_AMI_MAPPING[region],
-            instance_type=instance_type,
-            region=region,
-            service_name=INSTANCE_SERVICE_NAME,
-        ),
-    )
-    return SceptrePlan(context)
-
-
-def create_instance(*, ssh_key_path: str, aws_region: str, instance_type: str):
-    logger.warning("Creating instance")
-    result = _get_sceptre_plan(aws_region, instance_type).create()
-
-    logger.debug("Got sceptre result: %s", result)
-    if "complete" not in result.values():
-        raise Exception(f"sceptre command failed: {list(result.values())}")
-    logger.warning("Stack created")
-
-    while get_instance_state(aws_region) != "running":
-        logger.warning("Waiting to bootstrap: instance not yet running")
-        time.sleep(5)
-
-    logger.warning("Waiting until SSH access is available")
-    ip = get_ip(aws_region)
-
-    wait_until_port_is_open(ip, 22, sleep_time=3, max_attempts=10)
-    # Give it some extra time, AWS can throw fopen errors on apt-get update
-    # if this is too rushed
-    time.sleep(15)
-    logger.warning("Starting bootstrap")
-    bootstrap_instance(ssh_key_path=ssh_key_path, aws_region=aws_region)
-
-
-def update_instance(region: str, instance_type: str = None) -> Dict:
-    logger.warning("Updating instance")
-    result = _get_sceptre_plan(region, instance_type).update()
-
-    logger.debug("Got sceptre result: %s", result)
-    if "complete" not in result.values():
-        raise Exception(f"sceptre command failed: {list(result.values())}")
-    return result
-
-
-def delete_instance(region: str) -> Dict:
-    logger.warning("Deleting instance")
-    result = _get_sceptre_plan(region).delete()
-
-    logger.debug("Got sceptre result: %s", result)
-    if "complete" not in result.values():
-        raise Exception(f"sceptre command failed: {list(result.values())}")
-    return result
-
-
-# flake8: noqa: E501
-def bootstrap_instance(ssh_key_path, aws_region):
-    logger.warning("Bootstrapping instance, will take a few minutes")
-    configure_instance_cmd_s = """
-    set -x
-    && sudo apt-get -y update
-    && sudo apt-get -y install build-essential curl file git docker.io
-    && "sudo sed -i -e '/ExecStart=/ s/fd:\/\//127\.0\.0\.1:2375/' '/lib/systemd/system/docker.service'"
-    && sudo systemctl daemon-reload
-    && sudo systemctl restart docker.service
-    && sudo systemctl enable docker.service
-    && "sudo sed -i -e '/GatewayPorts/ s/^.*$/GatewayPorts yes/' '/etc/ssh/sshd_config'"
-    && sudo service sshd restart
-    && /bin/bash -c '"$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"'
-    && eval $(/home/linuxbrew/.linuxbrew/bin/brew shellenv)
-    && echo 'eval $(/home/linuxbrew/.linuxbrew/bin/brew shellenv)' >> /home/ubuntu/.profile
-    && brew install unison eugenmayer/dockersync/unox
-    && sudo cp "$(which unison)" /usr/local/bin/
-    && sudo cp "$(which unison-fsmonitor)" /usr/local/bin/
-    """
-    ssh_connect(
-        ssh_key_path=ssh_key_path,
-        aws_region=aws_region,
-        ssh_cmd=configure_instance_cmd_s,
-    )
-
-
-def _build_ssh_cmd(ssh_key_path, ip, ssh_cmd=None, options=None):
-    ssh_cmd = ssh_cmd if ssh_cmd else ""
-    options = options if options else ""
-
-    cmd_s = f"""
-    ssh -o StrictHostKeyChecking=no -i {ssh_key_path}
-    {options} {INSTANCE_USERNAME}@{ip} {ssh_cmd}
-    """
-
-    return shlex.split(cmd_s)
-
-
-def ssh_connect(
-    *, ssh_key_path: str, aws_region: str, ssh_cmd: str = None, options: str = None
-):
-    ip = get_ip(aws_region)
-    cmd = _build_ssh_cmd(ssh_key_path, ip, ssh_cmd, options)
-
-    os.execvp(cmd[0], cmd)
-
-
-def ssh_run(*, ssh_key_path: str, ip: str, ssh_cmd: str):
-    cmd = _build_ssh_cmd(ssh_key_path, ip, ssh_cmd)
-    return subprocess.run(cmd, check=True)
-
-
-def create_keypair(ssh_key_path: str, aws_region: str) -> Dict:
-    path = ssh_key_path
-    subprocess.run(
-        shlex.split(f"ssh-keygen -t rsa -b 4096 -f {path}"),
-        check=True,
-        shell=True,
-        stdout=sys.stdout,
-        stderr=sys.stderr,
-    )
-    subprocess.run(
-        shlex.split(f"ssh-add -K {path}"),
-        check=True,
-        shell=True,
-        stdout=sys.stdout,
-        stderr=sys.stderr,
-    )
-    return import_key(
-        aws_region=aws_region, name=KEY_PAIR_NAME, file_location=f"{path}.pub",
-    )
-
-
-def get_unison_cmd(
-    replica_path: str,
-    sync_paths: List[str],
-    ssh_key_path: str,
-    sync_ignore_patterns: List[str],
-    ip: str,
-    force: bool = False,
-    repeat_watch: bool = False,
-) -> List[str]:
-    cmd_s = f"""
-    unison-gitignore {replica_path} 'ssh://{INSTANCE_USERNAME}@{ip}/{replica_path}'
-    -prefer {replica_path} -batch -sshargs '-i {ssh_key_path}'
-    """
-
-    parser = GitIgnoreToUnisonIgnore("/")
-    unison_patterns = parser.parse_gitignore(sync_ignore_patterns)
-    for unison_pattern in unison_patterns:
-        cmd_s += f' "{unison_pattern}"'
-
-    for sync_path in sync_paths:
-        cmd_s += f" -path {sync_path}"
-
-    if force:
-        cmd_s += f" -force {replica_path}"
-    if repeat_watch:
-        cmd_s += " -repeat watch"
-
-    return shlex.split(cmd_s.replace("\n", ""))
-
-
-def sync(
-    *,
-    dirs: List[str],
-    ssh_key_path: str,
-    sync_ignore_patterns_git: List[str],
-    aws_region: str,
-):
-    replica_path, sync_paths = get_replica_and_sync_paths_for_unison(dirs)
-    ip = get_ip(aws_region)
-
-    logger.warning("Ensuring remote directories exist")
-    ssh_cmd_s = f"sudo install -d -o {INSTANCE_USERNAME} -g {INSTANCE_USERNAME}"
-    for _dir in dirs:
-        ssh_cmd_s += f" -p {_dir}"
-    ssh_run(ssh_key_path=ssh_key_path, ip=ip, ssh_cmd=ssh_cmd_s)
-
-    # First push the local replica's contents to remote
-    logger.info("Pushing local files to remote server")
-    subprocess.run(
-        get_unison_cmd(
-            replica_path,
-            sync_paths,
-            ssh_key_path,
-            sync_ignore_patterns_git,
-            ip=ip,
-            force=True,
-        ),
-        check=True,
-    )
-
-    # Then watch for update
-    logger.info("Watching local and remote filesystems for changes")
-    watch_cmd = get_unison_cmd(
-        replica_path,
-        sync_paths,
-        ssh_key_path,
-        sync_ignore_patterns_git,
-        ip=ip,
-        repeat_watch=True,
-    )
-
-    logger.warning("")
-    logger.warning("Watching: %s", dirs)
-    logger.debug("Running command :%s", watch_cmd)
-    os.execvp(watch_cmd[0], watch_cmd)
+def create_remote_docker_client(
+    config: RemoteDockerConfigProfile,
+) -> RemoteDockerClient:
+    return RemoteDockerClient.from_config(config, SCEPTRE_PATH)

--- a/src/remote_docker_aws/sceptre/config/dev/config.yaml
+++ b/src/remote_docker_aws/sceptre/config/dev/config.yaml
@@ -1,2 +1,2 @@
-project_code: remote-docker
+project_code: {{ var.project_code }}
 region: {{ var.region }}

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -8,7 +8,6 @@ from unittest import mock
 import pytest
 from moto import mock_cloudformation, mock_ec2
 
-from remote_docker_aws.constants import SCEPTRE_PATH
 from remote_docker_aws.config import RemoteDockerConfigProfile
 from remote_docker_aws.core import (
     create_remote_docker_client,
@@ -82,7 +81,6 @@ class TestCore:
             ssh_key_pair_name="mock_key_pair_name",
             sync_dirs=["/fake/dir"],
             sync_ignore_patterns=["test.py"],
-            sceptre_path=SCEPTRE_PATH,
         )
 
     def test_get_ip_when_no_instances_running(self, remote_docker_client):


### PR DESCRIPTION
- move everything into a class to reduce duplication
- Also adds the `user_id` config variable so that instances can be identified uniquely for shared AWS accounts