### PR TITLE
remove `rd update` since it can be destructive and is not useful

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The downsides:
 1. Install pre-requisites
 
    Have [Homebrew](https://brew.sh/) (Available on both macOS and Linux now!)
-   
+
    Have [pipx](https://github.com/pipxproject/pipx)
 
     ```bash
@@ -45,7 +45,7 @@ The downsides:
    # Install unison sync utility
    brew install unison
 
-   # Install file-watcher driver for unison      
+   # Install file-watcher driver for unison
    # On MacOS:
    brew install autozimu/homebrew-formulas/unison-fsmonitor
 
@@ -209,19 +209,10 @@ The current configurable values are:
  - defaults to: `30` (GB)
  - Size of the ec2 volume.
 
- If you update `volume_size` after your instance has been created, then 
- performing an update will re-create the instance which might not be desired since it will wipe your volume.
- In this case, you can recreate your instance (`rd delete && rd create`), or [backup your volume](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSSnapshots.html) and run:
- ```
- rd update
- rd ssh "sudo growpart /dev/xvda 1 && sudo resize2fs /dev/xvda1"
- ```
- after which you can restore from your snapshot
-
 ---
 
 Profiles are a way to organize and override settings for different projects.
-Values nested in a profile override the values defined outside a profile, 
+Values nested in a profile override the values defined outside a profile,
 except for lists and dictionaries which are merged to the values outside the profile
 
 

--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ The current configurable values are:
 
 Profiles are a way to organize and override settings for different projects.
 Values nested in a profile override the values defined outside a profile,
-except for lists and dictionaries which are merged to the values outside the profile
+except for lists and dictionaries which are merged with the values outside the profile
 
 
 ## Cost

--- a/src/remote_docker_aws/cli_commands.py
+++ b/src/remote_docker_aws/cli_commands.py
@@ -107,17 +107,6 @@ def cmd_delete(client: RemoteDockerClient):
     print(client.delete_instance())
 
 
-@cli.command(name="update", help="Update the provisioned instance")
-@pass_config
-def cmd_update(client: RemoteDockerClient):
-    prompt = (
-        "Are you sure you want to update your instance?"
-        " This can have potential destructive consequences so only continue if you are sure"
-    )
-    click.confirm(prompt, abort=True)
-    print(client.update_instance())
-
-
 @cli.command(
     name="tunnel",
     help=(

--- a/src/remote_docker_aws/cli_commands.py
+++ b/src/remote_docker_aws/cli_commands.py
@@ -110,6 +110,11 @@ def cmd_delete(client: RemoteDockerClient):
 @cli.command(name="update", help="Update the provisioned instance")
 @pass_config
 def cmd_update(client: RemoteDockerClient):
+    prompt = (
+        "Are you sure you want to update your instance?"
+        " This can have potential destructive consequences so only continue if you are sure"
+    )
+    click.confirm(prompt, abort=True)
     print(client.update_instance())
 
 

--- a/src/remote_docker_aws/core.py
+++ b/src/remote_docker_aws/core.py
@@ -212,15 +212,6 @@ class RemoteDockerClient:
         logger.warning("Starting bootstrap")
         self.bootstrap_instance()
 
-    def update_instance(self) -> Dict:
-        logger.warning("Updating instance")
-        result = self._get_sceptre_plan().update()
-
-        logger.debug("Got sceptre result: %s", result)
-        if "complete" not in result.values():
-            raise Exception(f"sceptre command failed: {list(result.values())}")
-        return result
-
     def delete_instance(self) -> Dict:
         logger.warning("Deleting instance")
         result = self._get_sceptre_plan().delete()

--- a/src/remote_docker_aws/core.py
+++ b/src/remote_docker_aws/core.py
@@ -134,10 +134,10 @@ class RemoteDockerClient:
         remote_forwards = dict(self.remote_forwards, **extra_remote_forwards)
 
         ip = self.get_ip()
-        cmd_s = f"""
-        sudo ssh -v -o StrictHostKeyChecking=no -o "ServerAliveInterval=60" -N -T
-         -i {self.ssh_key_path} {INSTANCE_USERNAME}@{ip}
-        """
+        cmd_s = (
+            'sudo ssh -v -o StrictHostKeyChecking=no -o "ServerAliveInterval=60" -N -T'
+            f" -i {self.ssh_key_path} {INSTANCE_USERNAME}@{ip}"
+        )
 
         for port_from, port_to in DOCKER_PORT_FORWARD.items():
             cmd_s += f" -L localhost:{port_from}:localhost:{port_to}"
@@ -234,10 +234,10 @@ class RemoteDockerClient:
         ssh_cmd = ssh_cmd if ssh_cmd else ""
         options = options if options else ""
 
-        cmd_s = f"""
-        ssh -o StrictHostKeyChecking=no -i {self.ssh_key_path}
-        {options} {INSTANCE_USERNAME}@{self.get_ip()} {ssh_cmd}
-        """
+        cmd_s = (
+            f"ssh -o StrictHostKeyChecking=no -i {self.ssh_key_path}"
+            f" {options} {INSTANCE_USERNAME}@{self.get_ip()} {ssh_cmd}"
+        )
 
         return shlex.split(cmd_s)
 
@@ -298,10 +298,10 @@ class RemoteDockerClient:
         force: bool = False,
         repeat_watch: bool = False,
     ) -> List[str]:
-        cmd_s = f"""
-        unison-gitignore {replica_path} 'ssh://{INSTANCE_USERNAME}@{ip}/{replica_path}'
-        -prefer {replica_path} -batch -sshargs '-i {self.ssh_key_path}'
-        """
+        cmd_s = (
+            f"unison-gitignore {replica_path} 'ssh://{INSTANCE_USERNAME}@{ip}/{replica_path}'"
+            f" -prefer {replica_path} -batch -sshargs '-i {self.ssh_key_path}'"
+        )
 
         parser = GitIgnoreToUnisonIgnore("/")
         unison_patterns = parser.parse_gitignore(self.sync_ignore_patterns)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -88,7 +88,7 @@ class TestCLICommandsWithMoto:
 
     def test_update(self, cli_runner, instance):
         with instance():
-            result = cli_runner.invoke(cli, ["update"])
+            result = cli_runner.invoke(cli, ["update"], input="y")
         assert result.exit_code == 0
 
     @patch_exec

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -86,11 +86,6 @@ class TestCLICommandsWithMoto:
         create_instance()
         delete_instance()
 
-    def test_update(self, cli_runner, instance):
-        with instance():
-            result = cli_runner.invoke(cli, ["update"], input="y")
-        assert result.exit_code == 0
-
     @patch_exec
     def test_ssh(self, mock_exec, cli_runner, instance):
         with instance():


### PR DESCRIPTION
since `rd update` usually re-creates the instance, it can be surprising and lead to data loss. It also does not currently re-bootstrap the instance. Since in most cases it's simpler and more obvious what is happening doing an explicit `rd delete && rd create` that will be the alternative going forward 