### PR TITLE
use region from aws config

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,11 +52,11 @@ The downsides:
    # Or, on Linux since the above formula doesn't work:
    brew install eugenmayer/dockersync/unox
     ```
-    
+
 1. Generate and upload a keypair to AWS
 
     ```bash
-   # Note: bash users can use `rd` instead of `remote-docker-aws`. zsh users cannot since zsh aliases `rd` to `rmdir` (!) 
+   # Note: bash users can use `rd` instead of `remote-docker-aws`. zsh users cannot since zsh aliases `rd` to `rmdir` (!)
    remote-docker-aws create-keypair
     ```
 
@@ -171,7 +171,7 @@ The current configurable values are:
 #### `aws_profile` (takes precedence over `AWS_PROFILE`)
 - Needed in order to authenticate with AWS
 
-#### `aws_region` (takes precedence over `AWS_REGION`)
+#### `aws_region` (takes precedence over `AWS_REGION` and `.aws/config`)
 - The region to create the instance in
 
 #### `instance_type`

--- a/README.md
+++ b/README.md
@@ -168,9 +168,6 @@ Options:
 ```
 
 The current configurable values are:
-#### `aws_profile` (takes precedence over `AWS_PROFILE`)
-- Needed in order to authenticate with AWS
-
 #### `aws_region` (takes precedence over `AWS_REGION` and `.aws/config`)
 - The region to create the instance in
 

--- a/src/remote_docker_aws/cli_commands.py
+++ b/src/remote_docker_aws/cli_commands.py
@@ -41,19 +41,6 @@ def _convert_port_forward_to_dict(
 @click.pass_context
 def cli(ctx, profile_name, config_path):
     config = RemoteDockerConfigProfile.from_json_file(config_path, profile_name)
-
-    try:
-        aws_profile = config.aws_profile
-        os.environ["AWS_PROFILE"] = aws_profile
-    except KeyError:
-        pass
-
-    try:
-        aws_region = config.aws_region
-        os.environ["AWS_REGION"] = aws_region
-    except KeyError:
-        pass
-
     logger.debug("Config: %s", config)
     ctx.obj = create_remote_docker_client(config)
 

--- a/src/remote_docker_aws/cli_commands.py
+++ b/src/remote_docker_aws/cli_commands.py
@@ -1,5 +1,4 @@
 import click
-import os
 from typing import Tuple
 
 from .core import (

--- a/src/remote_docker_aws/config.py
+++ b/src/remote_docker_aws/config.py
@@ -2,6 +2,8 @@ import json
 import os
 from typing import List
 
+import boto3
+
 from .constants import (
     KEY_PAIR_NAME,
     INSTANCE_SERVICE_NAME,
@@ -99,6 +101,15 @@ class JSONConfigWithProfile(JSONConfig):
 
 
 class RemoteDockerConfigProfile(JSONConfigWithProfile):
+    _boto3_session_cached = None
+
+    @property
+    def _boto3_session(self):
+        if not self._boto3_session_cached:
+            self._boto3_session_cached = boto3.session.Session()
+
+        return self._boto3_session_cached
+
     @property
     def aws_profile(self) -> str:
         if "AWS_PROFILE" in os.environ:
@@ -107,8 +118,8 @@ class RemoteDockerConfigProfile(JSONConfigWithProfile):
 
     @property
     def aws_region(self) -> str:
-        if "AWS_REGION" in os.environ:
-            return self.get_attribute("aws_region", os.environ["AWS_REGION"])
+        if self._boto3_session.region_name:
+            return self.get_attribute("aws_region", self._boto3_session.region_name)
         return self.get_attribute("aws_region")
 
     @property

--- a/src/remote_docker_aws/config.py
+++ b/src/remote_docker_aws/config.py
@@ -111,16 +111,8 @@ class RemoteDockerConfigProfile(JSONConfigWithProfile):
         return self._boto3_session_cached
 
     @property
-    def aws_profile(self) -> str:
-        if "AWS_PROFILE" in os.environ:
-            return self.get_attribute("aws_profile", os.environ["AWS_PROFILE"])
-        return self.get_attribute("aws_profile")
-
-    @property
     def aws_region(self) -> str:
-        if self._boto3_session.region_name:
-            return self.get_attribute("aws_region", self._boto3_session.region_name)
-        return self.get_attribute("aws_region")
+        return self.get_attribute("aws_region", self._boto3_session.region_name)
 
     @property
     def key_path(self) -> str:

--- a/src/remote_docker_aws/core.py
+++ b/src/remote_docker_aws/core.py
@@ -217,6 +217,7 @@ class RemoteDockerClient:
 
     def create_instance(self):
         logger.warning("Creating instance")
+        logger.warning(self.aws_region)
         result = self._get_sceptre_plan().create()
 
         logger.debug("Got sceptre result: %s", result)

--- a/src/remote_docker_aws/core.py
+++ b/src/remote_docker_aws/core.py
@@ -217,7 +217,6 @@ class RemoteDockerClient:
 
     def create_instance(self):
         logger.warning("Creating instance")
-        logger.warning(self.aws_region)
         result = self._get_sceptre_plan().create()
 
         logger.debug("Got sceptre result: %s", result)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -11,6 +11,10 @@ from remote_docker_aws.cli_commands import cli
 from remote_docker_aws.config import RemoteDockerConfigProfile
 
 
+AWS_PROFILE = "mock_aws_profile"
+AWS_REGION = "ca-central-1"
+
+
 patch_exec = mock.patch("os.execvp", autospec=True)
 patch_run = mock.patch("subprocess.run", autospec=True)
 
@@ -23,6 +27,16 @@ def test_cli_entrypoint_runs_successfully():
     assert output
 
 
+class MockProfile(RemoteDockerConfigProfile):
+    @property
+    def aws_profile(self) -> str:
+        raise KeyError()
+
+    @property
+    def aws_region(self) -> str:
+        return AWS_REGION
+
+
 @mock_cloudformation
 @mock_ec2
 class TestCLICommandsWithMoto:
@@ -32,9 +46,7 @@ class TestCLICommandsWithMoto:
             "remote_docker_aws.cli_commands.RemoteDockerConfigProfile.from_json_file",
             autospec=True,
         ) as mock_from_json_file:
-            mock_from_json_file.return_value = RemoteDockerConfigProfile(
-                config_dict=dict(aws_region="ca-central-1")
-            )
+            mock_from_json_file.return_value = MockProfile({})
             yield
 
     @pytest.fixture

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -11,7 +11,6 @@ from remote_docker_aws.cli_commands import cli
 from remote_docker_aws.config import RemoteDockerConfigProfile
 
 
-AWS_PROFILE = "mock_aws_profile"
 AWS_REGION = "ca-central-1"
 
 
@@ -28,10 +27,6 @@ def test_cli_entrypoint_runs_successfully():
 
 
 class MockProfile(RemoteDockerConfigProfile):
-    @property
-    def aws_profile(self) -> str:
-        raise KeyError()
-
     @property
     def aws_region(self) -> str:
         return AWS_REGION

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -54,27 +54,6 @@ def test_settings_with_defaults():
     assert config.volume_size == 30
 
 
-def test_settings_with_no_defaults():
-    config = RemoteDockerConfigProfile({})
-
-    with pytest.raises(KeyError):
-        config.aws_profile
-
-    with pytest.raises(KeyError):
-        config.aws_region
-
-
-@mock.patch.dict(
-    os.environ, {"AWS_PROFILE": "mock_aws_profile", "AWS_REGION": "mock_aws_region"}
-)
-def test_aws_profile_uses_env_var_fallback():
-    config = RemoteDockerConfigProfile({})
-    assert config.aws_profile == "mock_aws_profile"
-
-    config = RemoteDockerConfigProfile(dict(aws_profile="override_aws_profile"))
-    assert config.aws_profile == "override_aws_profile"
-
-
 @mock.patch(
     "remote_docker_aws.config.RemoteDockerConfigProfile._boto3_session",
     new_callable=mock.PropertyMock,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -67,10 +67,19 @@ def test_settings_with_no_defaults():
 @mock.patch.dict(
     os.environ, {"AWS_PROFILE": "mock_aws_profile", "AWS_REGION": "mock_aws_region"}
 )
-def test_settings_with_env_var_fallback():
+def test_aws_profile_uses_env_var_fallback():
     config = RemoteDockerConfigProfile({})
     assert config.aws_profile == "mock_aws_profile"
-    assert config.aws_region == "mock_aws_region"
+
+
+@mock.patch(
+    "remote_docker_aws.config.RemoteDockerConfigProfile._boto3_session",
+    new_callable=mock.PropertyMock,
+)
+def test_aws_region_uses_boto_session_fallback(mock_session):
+    mock_session.return_value = mock.MagicMock(region_name="session_region")
+    config = RemoteDockerConfigProfile({})
+    assert config.aws_region == "session_region"
 
 
 def test_settings_with_profile():

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -71,15 +71,22 @@ def test_aws_profile_uses_env_var_fallback():
     config = RemoteDockerConfigProfile({})
     assert config.aws_profile == "mock_aws_profile"
 
+    config = RemoteDockerConfigProfile(dict(aws_profile="override_aws_profile"))
+    assert config.aws_profile == "override_aws_profile"
+
 
 @mock.patch(
     "remote_docker_aws.config.RemoteDockerConfigProfile._boto3_session",
     new_callable=mock.PropertyMock,
 )
 def test_aws_region_uses_boto_session_fallback(mock_session):
-    mock_session.return_value = mock.MagicMock(region_name="session_region")
+    mock_session.return_value = mock.MagicMock(region_name="session_aws_region")
+
     config = RemoteDockerConfigProfile({})
-    assert config.aws_region == "session_region"
+    assert config.aws_region == "session_aws_region"
+
+    config = RemoteDockerConfigProfile(dict(aws_region="override_aws_region"))
+    assert config.aws_region == "override_aws_region"
 
 
 def test_settings_with_profile():


### PR DESCRIPTION
Resolves https://github.com/lime-green/remote-docker-aws/issues/20
Also removes `aws_profile` config variable, it's not useful IMO and `AWS_PROFILE=<...>` can be used instead if needed